### PR TITLE
fix(ehole): correct bin path for v3.1

### DIFF
--- a/bucket/ehole.json
+++ b/bucket/ehole.json
@@ -11,7 +11,7 @@
     },
     "bin": [
         [
-            "Ehole3.0-Win.exe",
+            "EHole_windows_amd64\\EHole_windows_amd64.exe",
             "ehole"
         ]
     ],


### PR DESCRIPTION
修正ehole的bin路径